### PR TITLE
Fixed the error that's fired for pages without 'dir' attribute

### DIFF
--- a/saber-toast.js
+++ b/saber-toast.js
@@ -52,7 +52,7 @@ class SaberToast {
         this.fire(params)
     }
     fire(params) {
-        const DEFAULT_RTL = document.querySelector('html').getAttribute('dir').toLowerCase() === 'rtl';
+        const DEFAULT_RTL = document.querySelector('html').getAttribute('dir')?.toLowerCase() === 'rtl';
         const { title, text, delay, duration, rtl, position } = { title: "", text: "", delay: 200, duration: 2600, rtl: DEFAULT_RTL, position: "bottom-right", ...params }
         const div = document.createElement('div')
         div.classList.add('saber-toast')


### PR DESCRIPTION
Thanks to the last merge, the 'fire' method could get the 'dir' attribute value and update the toast location based on it. But there was a small issue, if there was no 'dir' attribute in the page, the method fires an error and no toast is presented. That issue even broke the example [https://ahmed0saber.github.io/saber-toast/example](https://ahmed0saber.github.io/saber-toast/example).
I used the optional chaining operator to return undefined if no 'dir' attribute was presented. If the user didn't define the 'rtl' property value and there is no 'dir' attribute in the page, then the default direction will be 'ltr' and the default toast location will be left.